### PR TITLE
Ensure the use of project-wide SSH keys is disabled

### DIFF
--- a/modules/instance/main.tf
+++ b/modules/instance/main.tf
@@ -38,7 +38,11 @@ resource "google_compute_instance" "prueba-vmimage" {
       # Include this section to give the VM an external ip address
     }
   }
+  metadata = {
+    block-project-ssh-keys = true
+    }
 }
+
 
 
 resource "google_compute_machine_image" "image" {


### PR DESCRIPTION
This pull request improves our infrastructure by fixing a security issue found by [Shisho Cloud](https://shisho.dev).

## Description from Shisho Cloud

Project-wide SSH keys increase the risk of a compromise of them. You can use instance-level keys and OS login instead.

